### PR TITLE
add Special DateTime InjectAttribute

### DIFF
--- a/src/Be.Stateless.BizTalk.Process.Unit.Tests/Unit/IO/Extensions/StreamExtensionsFixture.cs
+++ b/src/Be.Stateless.BizTalk.Process.Unit.Tests/Unit/IO/Extensions/StreamExtensionsFixture.cs
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System;
 using System.Xml.Linq;
 using Be.Stateless.BizTalk.ContextProperties;
 using Be.Stateless.IO;
@@ -27,6 +28,16 @@ namespace Be.Stateless.BizTalk.Unit.IO.Extensions
 {
 	public class StreamExtensionsFixture
 	{
+		[Fact]
+		public void InjectDateTimeAttribute()
+		{
+			var sut = new StringStream(XDocument.Parse("<root />").ToString(SaveOptions.DisableFormatting));
+
+			var stream = sut.InjectAttribute(SBMessagingProperties.EnqueuedTimeUtc, DateTime.Parse("2022-02-24T11:00:00.123456z"));
+
+			stream.ReadToEnd().Should().Be("<root EnqueuedTimeUtc=\"2022-02-24T12:00:00.1234560+01:00\" />");
+		}
+
 		[Fact]
 		public void InjectIntegerAttribute()
 		{

--- a/src/Be.Stateless.BizTalk.Process.Unit/Unit/IO/Extensions/StreamExtensions.cs
+++ b/src/Be.Stateless.BizTalk.Process.Unit/Unit/IO/Extensions/StreamExtensions.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License
 
-// Copyright © 2012 - 2021 François Chabot
+// Copyright © 2012 - 2022 François Chabot
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 #endregion
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Xml;
@@ -39,6 +40,12 @@ namespace Be.Stateless.BizTalk.Unit.IO.Extensions
 			where T : MessageContextPropertyBase, new()
 		{
 			return stream.InjectAttribute(property.Name, value.ToString());
+		}
+
+		public static Stream InjectAttribute<T>(this Stream stream, MessageContextProperty<T, DateTime> property, DateTime value)
+			where T : MessageContextPropertyBase, new()
+		{
+			return stream.InjectAttribute(property.Name, value.ToString("o"));
 		}
 
 		private static Stream InjectAttribute(this Stream stream, string name, string value)


### PR DESCRIPTION
There are a problem when you want to inject a datetime attribute in the xml like SBMessagingProperties.EnqueuedTimeUtc propertie, the format is not correct in the xml (ex: 2/3/2019 6:44:33 PM) because you make a ToString() on every types, DateTime need to have a special format for the ToString().